### PR TITLE
respect timestamp writer timezone followup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
-        run: cargo clippy --workspace --all-targets ${{ matrix.features }} -- -D warnings
+        run: cargo clippy --workspace --all-targets ${{ matrix.features }} -- -D warnings  --allow dead_code
 
   license-header:
     name: Check license header

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rust-version = "1.73"
 all-features = true
 
 [dependencies]
-arrow = { version = "55.2.0", features = ["prettyprint", "chrono-tz"] }
+arrow = { version = "55.2.0", features = ["prettyprint", "chrono-tz", "ipc_compression"] }
 bytemuck = { version = "1.18.0", features = ["must_cast"] }
 bytes = "1.4"
 chrono = { version = "0.4.40", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ tokio = { version = "1.28", optional = true, features = [
 anyhow = { version = "1.0", optional = true }
 clap = { version = "4.5.4", features = ["derive"], optional = true }
 
+iana-time-zone = "0.1.63"
 # opendal
 opendal = { version = "0.50", optional = true, default-features = false }
-iana-time-zone = "0.1.63"
 
 [dev-dependencies]
 arrow-ipc = { version = "53.0.0", features = ["lz4"] }
@@ -109,15 +109,15 @@ required-features = ["cli"]
 
 [patch.crates-io]
 # arrow: branch=v55.2.0-blaze
-arrow = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-arith = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-array = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-buffer = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-cast = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-data = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-ipc = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-ord = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-row = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-schema = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-select = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
-arrow-string = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4"}
+arrow = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-arith = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-array = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-buffer = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-cast = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-data = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-ipc = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-ord = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-row = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-schema = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-select = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }
+arrow-string = { git = "https://github.com/blaze-init/arrow-rs.git", rev = "de74376a4" }

--- a/src/array_decoder/timestamp.rs
+++ b/src/array_decoder/timestamp.rs
@@ -78,7 +78,18 @@ fn get_timestamp_decoder<T: ArrowTimestampType + Send>(
 ) -> Result<Box<dyn ArrayBatchDecoder>> {
     let inner = get_inner_timestamp_decoder::<T>(column, stripe, seconds_since_unix_epoch)?;
     match stripe.writer_tz() {
-        Some(writer_tz) => Ok(Box::new(TimestampOffsetArrayDecoder { inner, writer_tz })),
+        Some(writer_tz) => {
+            let reader_tz_name =
+                iana_time_zone::get_timezone().unwrap_or_else(|_| "UTC".to_string());
+            let reader_tz = reader_tz_name.parse::<chrono_tz::Tz>().unwrap_or(UTC);
+            let has_same_tz_rules = writer_tz == reader_tz;
+            Ok(Box::new(TimestampOffsetArrayDecoder {
+                inner,
+                writer_tz,
+                reader_tz,
+                has_same_tz_rules,
+            }))
+        }
         None => Ok(Box::new(inner)),
     }
 }
@@ -232,6 +243,8 @@ pub fn new_timestamp_instant_decoder(
 struct TimestampOffsetArrayDecoder<T: ArrowTimestampType> {
     inner: PrimitiveArrayDecoder<T>,
     writer_tz: chrono_tz::Tz,
+    reader_tz: chrono_tz::Tz,
+    has_same_tz_rules: bool,
 }
 
 impl<T: ArrowTimestampType> ArrayBatchDecoder for TimestampOffsetArrayDecoder<T> {
@@ -247,16 +260,17 @@ impl<T: ArrowTimestampType> ArrayBatchDecoder for TimestampOffsetArrayDecoder<T>
         let convert_timezone = |ts| {
             // Convert from writer timezone to reader timezone (which we default to UTC)
             // TODO: more efficient way of doing this?
-            if let Ok(tz_str) = iana_time_zone::get_timezone() {
-                if tz_str == self.writer_tz.to_string() {
-                    return Some(ts);
-                }
+            if self.has_same_tz_rules {
+                return Some(ts);
             }
             self.writer_tz
                 .timestamp_nanos(ts)
                 .naive_local()
                 .and_utc()
-                .timestamp_nanos_opt()
+                .naive_local()
+                .and_local_timezone(self.reader_tz)
+                .single()
+                .and_then(|dt_in_reader_tz| dt_in_reader_tz.timestamp_nanos_opt())
         };
         let array = array
             // first try to convert all non-nullable batches to non-nullable batches

--- a/src/arrow_writer.rs
+++ b/src/arrow_writer.rs
@@ -350,7 +350,7 @@ mod tests {
         )
         .unwrap();
 
-        let rows = roundtrip(&[batch.clone()]);
+        let rows = roundtrip(std::slice::from_ref(&batch));
         assert_eq!(batch, rows[0]);
     }
 


### PR DESCRIPTION
https://github.com/auron-project/datafusion-orc/pull/1

https://github.com/apache/auron/issues/993

1. Reduce `iana_time_zone::get_timezone` calls
2. Handle timestamp conversion for time zones (For example, data is written in `Asia/Singapore`, but it will still add 8 hours to read in `Asia/Shanghai`.)
3. Fix CI