### PR TITLE
fix delta overflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         command: check license
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ private/
 /perf.*
 /flamegraph.svg
 
+.DS_Store

--- a/src/encoding/integer/mod.rs
+++ b/src/encoding/integer/mod.rs
@@ -244,12 +244,12 @@ impl NInt for i16 {
 
     #[inline]
     fn add_i64(self, i: i64) -> Option<Self> {
-        i.try_into().ok().and_then(|i| self.checked_add(i))
+        self.as_i64().checked_add(i).and_then(|v| v.try_into().ok())
     }
 
     #[inline]
     fn sub_i64(self, i: i64) -> Option<Self> {
-        i.try_into().ok().and_then(|i| self.checked_sub(i))
+        self.as_i64().checked_sub(i).and_then(|v| v.try_into().ok())
     }
 
     #[inline]
@@ -278,12 +278,12 @@ impl NInt for i32 {
 
     #[inline]
     fn add_i64(self, i: i64) -> Option<Self> {
-        i.try_into().ok().and_then(|i| self.checked_add(i))
+        self.as_i64().checked_add(i).and_then(|v| v.try_into().ok())
     }
 
     #[inline]
     fn sub_i64(self, i: i64) -> Option<Self> {
-        i.try_into().ok().and_then(|i| self.checked_sub(i))
+        self.as_i64().checked_sub(i).and_then(|v| v.try_into().ok())
     }
 
     #[inline]

--- a/src/encoding/integer/rle_v2/delta.rs
+++ b/src/encoding/integer/rle_v2/delta.rs
@@ -286,4 +286,30 @@ mod tests {
         }
         assert_eq!(expected, out);
     }
+
+    #[test]
+    fn test_i32_add_sub_i64() {
+        let v = i32::MIN;
+        let i = (i32::MAX as i64) * 2;
+        let add_result = v.add_i64(i);
+        assert_eq!(add_result, Some(2147483646));
+
+        let v = i32::MIN;
+        let i = -(i32::MAX as i64) * 2;
+        let sub_result = v.sub_i64(i);
+        assert_eq!(sub_result, Some(2147483646));
+    }
+
+    #[test]
+    fn test_i16_add_sub_i64() {
+        let v = i16::MIN;
+        let i = (i16::MAX as i64) * 2;
+        let add_result = v.add_i64(i);
+        assert_eq!(add_result, Some(32766i16));
+
+        let v = i16::MIN;
+        let i = -(i16::MAX as i64) * 2;
+        let sub_result = v.sub_i64(i);
+        assert_eq!(sub_result, Some(32766i16));
+    }
 }


### PR DESCRIPTION
https://github.com/apache/auron/issues/1289

The original logic is to convert i64 to i32 and then add it to i32, which may overflow.

The logic of PR converts i32 to i64 and then converts it to i32, return to i32, avoid overflow.

<img width="1014" height="478" alt="9d5f30f6163744a21982ae7ef666c5e7" src="https://github.com/user-attachments/assets/e8a4367b-31f1-4026-af67-365bc1e6d315" />
